### PR TITLE
Fix missing stdint.h declarations if mgos_dht.h is the first include in client app

### DIFF
--- a/include/mgos_dht.h
+++ b/include/mgos_dht.h
@@ -26,6 +26,7 @@
 
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mgos_dht.c
+++ b/src/mgos_dht.c
@@ -20,7 +20,6 @@
  * [mgos_dht.c](https://github.com/mongoose-os-libs/dht/blob/master/src/mgos_dht.c)
  */
 
-#include <stdint.h>
 #include "mgos_dht.h"
 #include "mgos_gpio.h"
 #include "mgos_hal.h"


### PR DESCRIPTION
```
In file included from /home/liviu/mos/dht22-test/src/main.c:18:
/home/liviu/.mos/deps/dht/include/mgos_dht.h:40:3: error: unknown type name 'uint32_t'
   40 |   uint32_t read;                 // calls to _read()
      |   ^~~~~~~~
```